### PR TITLE
Parse and display death data from IHHME data files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
         "varsIgnorePattern": "[iI]gnored"
       }
     ],
+    "@typescript-eslint/interface-name-prefix": "off",
     "react/jsx-uses-vars": "error",
     "react/react-in-jsx-scope": "off",
     "react/prop-types": 0

--- a/components/IHMEParser.module.scss
+++ b/components/IHMEParser.module.scss
@@ -1,0 +1,35 @@
+.fileDrop {
+  $borderRadius: 4px;
+
+  /* relatively position the container bc the contents are absolute */
+  position: relative;
+  height: 100px;
+  border: 3px #ccc dashed;
+  margin: 16px;
+  border-radius: $borderRadius;
+
+  .fileDropTarget {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    border-radius: $borderRadius;
+  }
+
+  .fileDropTarget.fileDropDraggingOverFrame {
+    /* overlay a black mask when dragging over the frame */
+    border: none;
+    background-color: rgba(0, 0, 0, 0.25);
+    box-shadow: none;
+    z-index: 50;
+
+    color: white;
+  }
+
+  .fileDropTarget.fileDropDraggingOverTarget {
+    /* turn stuff orange when we are dragging over the target */
+    color: #ff6e40;
+    box-shadow: 0 0 13px 3px #ff6e40;
+  }
+}

--- a/components/IHMEParser.tsx
+++ b/components/IHMEParser.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import Spinner from "react-bootstrap/spinner";
+import Spinner from "react-bootstrap/Spinner";
 import { FileDrop, FileDropProps } from "react-file-drop";
 import Papa, { ParseResult } from "papaparse";
 import { ChartPoint } from "chart.js";

--- a/components/IHMEParser.tsx
+++ b/components/IHMEParser.tsx
@@ -1,0 +1,25 @@
+import { FileDrop, FileDropProps } from "react-file-drop";
+
+import styles from "./IHMEParser.module.scss";
+
+const IHMEParser = (): JSX.Element => {
+  const onFileDrop: FileDropProps["onDrop"] = (files, eventIgnored) => {
+    console.log("Files", files);
+  };
+
+  return (
+    <FileDrop
+      className={styles.fileDrop}
+      targetClassName={`${styles.fileDropTarget} d-flex justify-content-center align-items-center`}
+      draggingOverFrameClassName={styles.fileDropDraggingOverFrame}
+      draggingOverTargetClassName={styles.fileDropDraggingOverTarget}
+      onDrop={onFileDrop}
+    >
+      Drop some files here!
+    </FileDrop>
+  );
+};
+
+IHMEParser.displayName = "IHMEParser";
+
+export default IHMEParser;

--- a/components/IHMEParser.tsx
+++ b/components/IHMEParser.tsx
@@ -1,10 +1,139 @@
+import { useState, useEffect } from "react";
 import { FileDrop, FileDropProps } from "react-file-drop";
+import Papa, { ParseResult } from "papaparse";
+import { ChartPoint } from "chart.js";
+import dayjs from "dayjs";
 
 import styles from "./IHMEParser.module.scss";
 
-const IHMEParser = (): JSX.Element => {
-  const onFileDrop: FileDropProps["onDrop"] = (files, eventIgnored) => {
-    console.log("Files", files);
+interface IHMEDataPoint {
+  location_name: string;
+  date_reported: string;
+  date: string;
+  allbed_mean: string;
+  allbed_lower: string;
+  allbed_upper: string;
+  ICUbed_mean: string;
+  ICUbed_lower: string;
+  ICUbed_upper: string;
+  InvVen_mean: string;
+  InvVen_lower: string;
+  InvVen_upper: string;
+  deaths_mean: string;
+  deaths_lower: string;
+  deaths_upper: string;
+  admis_mean: string;
+  admis_lower: string;
+  admis_upper: string;
+  newICU_mean: string;
+  newICU_lower: string;
+  newICU_upper: string;
+  totdea_mean: string;
+  totdea_lower: string;
+  totdea_upper: string;
+  bedover_mean: string;
+  bedover_lower: string;
+  bedover_upper: string;
+  icuover_mean: string;
+  icuover_lower: string;
+  icuover_upper: string;
+}
+
+type IHMEDatum = keyof IHMEDataPoint;
+type IHMEChartData = { [key: string]: ChartPoint[] };
+
+export interface IHMEParserProps {
+  location?: string;
+  yDatum?: IHMEDatum;
+
+  onUpdate?(data: IHMEChartData): void;
+}
+
+const IHMEParser = ({
+  location = "Massachusetts",
+  yDatum = "deaths_mean",
+  onUpdate,
+}: IHMEParserProps): JSX.Element => {
+  type ParsedData = { [key: string]: { file: File; data: IHMEDataPoint[] } };
+  const [parsedData, setParsedData] = useState<ParsedData>({});
+
+  // Invoke onUpdate() callback function whenever a change to the parsed IHME
+  // model data has been made, or the user has chosen to alter the information
+  // to be plotted. A dependency list containing `parsedData`, `location`,
+  // and `yDatum` is provided to prevent any unnecessary calls to the callback
+  // function.
+  useEffect(() => {
+    const data = Object.keys(parsedData).reduce<IHMEChartData>(
+      (allData, filename) => {
+        // Filter data for appropriate location
+        const { file, data } = parsedData[filename];
+        const filteredData = data.filter(
+          (value) => value.location_name == location
+        );
+
+        // Extract relevant chart data
+        const label = dayjs(file.lastModified).format("MM-DD-YYYY");
+        const returnData = filteredData.map((value) => {
+          const date = dayjs(
+            value["date_reported"] || value["date"],
+            "YYYY-MM-DD"
+          );
+          return {
+            x: date.toDate(),
+            y: parseFloat(value[yDatum]),
+          };
+        });
+
+        // Only include data if the dataset is non-zero
+        if (returnData.length > 0) {
+          allData[label] = returnData;
+        }
+
+        return allData;
+      },
+      {}
+    );
+
+    onUpdate?.(data);
+  }, [parsedData, location, yDatum]);
+
+  const onFileDrop: FileDropProps["onDrop"] = async (files, eventIgnored) => {
+    const firstFile = files?.[0];
+    if (firstFile) {
+      // Only parse data if it has not been parsed yet
+      const fileId = `${firstFile.name}-${firstFile.lastModified}-${firstFile.size}`;
+      const { name } = firstFile;
+      if (parsedData[name]) {
+        return;
+      }
+
+      const result = await new Promise<ParseResult>((resolve, reject) => {
+        const result = Papa.parse(firstFile, {
+          header: true,
+          complete: (result, fileIgnored) => {
+            resolve(result);
+          },
+          error: (error, fileIgnored) => {
+            reject(error);
+          },
+        });
+
+        if (result) {
+          resolve(result);
+        }
+      });
+
+      const { data } = result;
+      if (data) {
+        const newData = { ...parsedData };
+        newData[fileId] = {
+          file: firstFile,
+          data,
+        };
+
+        setParsedData(newData);
+      }
+    }
   };
 
   return (

--- a/components/IHMEParser.tsx
+++ b/components/IHMEParser.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import Spinner from "react-bootstrap/spinner";
 import { FileDrop, FileDropProps } from "react-file-drop";
 import Papa, { ParseResult } from "papaparse";
 import { ChartPoint } from "chart.js";
@@ -56,6 +57,7 @@ const IHMEParser = ({
 }: IHMEParserProps): JSX.Element => {
   type ParsedData = { [key: string]: { file: File; data: IHMEDataPoint[] } };
   const [parsedData, setParsedData] = useState<ParsedData>({});
+  const [isParsing, setIsParsing] = useState(false);
 
   // Invoke onUpdate() callback function whenever a change to the parsed IHME
   // model data has been made, or the user has chosen to alter the information
@@ -99,6 +101,8 @@ const IHMEParser = ({
 
   const onFileDrop: FileDropProps["onDrop"] = async (files, eventIgnored) => {
     if (files) {
+      setIsParsing(true);
+
       const newData = { ...parsedData };
       let dataUpdated = false;
 
@@ -143,6 +147,8 @@ const IHMEParser = ({
       if (dataUpdated) {
         setParsedData(newData);
       }
+
+      setIsParsing(false);
     }
   };
 
@@ -154,7 +160,15 @@ const IHMEParser = ({
       draggingOverTargetClassName={styles.fileDropDraggingOverTarget}
       onDrop={onFileDrop}
     >
-      Drop some files here!
+      {isParsing ? (
+        <>
+          <span>Parsing data…</span>
+          &nbsp;
+          <Spinner animation="border" size="sm" />
+        </>
+      ) : (
+        "Drop some files here!"
+      )}
     </FileDrop>
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1328,6 +1328,14 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.11.1.tgz",
       "integrity": "sha512-eWQGP3qtxwL8FGneRrC5DwrJLGN4/dH1clNTuLfN81HCrxVtxRjygDTUoZJ5ASlDEeo0ppYFQjQIlXhtXpOn6g=="
     },
+    "@types/papaparse": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.0.3.tgz",
+      "integrity": "sha512-SgWGWnBGxl6XgjKDM2eoDg163ZFQtH6m6C2aOuaAf1T2gUB3rjaiPDDARbY9WlacRgZqieRG9imAfJaJ+5ouDA==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/prop-types": {
       "version": "15.7.3",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
@@ -5173,6 +5181,11 @@
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
+    "papaparse": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.2.0.tgz",
+      "integrity": "sha512-ylq1wgUSnagU+MKQtNeVqrPhZuMYBvOSL00DHycFTCxownF95gpLAk1HiHdUW77N8yxRq1qHXLdlIPyBSG9NSA=="
     },
     "parallel-transform": {
       "version": "1.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6084,6 +6084,14 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-file-drop": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/react-file-drop/-/react-file-drop-3.0.6.tgz",
+      "integrity": "sha512-OXfSpA8YY/OsKNITXPAOr+Rar8izqNZkx/N7B5vkp00AhQOFvj8ctC4bWInq1Mzpm4De5+XfpXAYbj4D4ze1QA==",
+      "requires": {
+        "prop-types": "^15.7.2"
+      }
+    },
     "react-is": {
       "version": "16.8.6",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.8.6.tgz",
@@ -6445,6 +6453,14 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "sass": {
+      "version": "1.26.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.26.3.tgz",
+      "integrity": "sha512-5NMHI1+YFYw4sN3yfKjpLuV9B5l7MqQ6FlkTcC4FT+oHbBRUZoSjHrrt/mE0nFXJyY2kQtU9ou9HxvFVjLFuuw==",
+      "requires": {
+        "chokidar": ">=2.0.0 <4.0.0"
+      }
     },
     "sass-loader": {
       "version": "8.0.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@types/chart.js": "^2.9.19",
     "@types/node": "^13.11.1",
+    "@types/papaparse": "^5.0.3",
     "@types/react": "^16.9.34",
     "bootstrap": "^4.4.1",
     "chart.js": "^2.9.3",
@@ -29,6 +30,7 @@
     "isomorphic-unfetch": "^3.0.0",
     "jquery": "^3.5.0",
     "next": "^9.3.5",
+    "papaparse": "^5.2.0",
     "popper.js": "^1.16.1",
     "react": "^16.13.1",
     "react-bootstrap": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "react-bootstrap": "^1.0.0",
     "react-chartjs-2": "^2.9.0",
     "react-dom": "^16.13.1",
+    "react-file-drop": "^3.0.6",
+    "sass": "^1.26.3",
     "typescript": "^3.8.3"
   },
   "devDependencies": {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,9 @@
+import { AppProps } from "next/app";
+
+import "../styles.scss";
+
+const IHMEComparisonApp = ({ Component, pageProps }: AppProps): JSX.Element => {
+  return <Component {...pageProps} />;
+};
+
+export default IHMEComparisonApp;

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,6 +4,7 @@ import { NextPage } from "next";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import { FormControlProps } from "react-bootstrap/FormControl";
+import IHMEParser from "../components/IHMEParser";
 import Row from "react-bootstrap/Row";
 import StateDropdown from "../components/StateDropdown";
 import CTPPlot, { CTPDataPoint } from "../components/CTPPlot";
@@ -44,6 +45,11 @@ const Index: NextPage = () => {
       <Row>
         <Col>
           <StateDropdown onChange={onChange} />
+        </Col>
+      </Row>
+      <Row>
+        <Col>
+          <IHMEParser />
         </Col>
       </Row>
       <Row>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -4,10 +4,13 @@ import { NextPage } from "next";
 import Col from "react-bootstrap/Col";
 import Container from "react-bootstrap/Container";
 import { FormControlProps } from "react-bootstrap/FormControl";
-import IHMEParser from "../components/IHMEParser";
+import IHMEParser, { IHMEParserProps } from "../components/IHMEParser";
 import Row from "react-bootstrap/Row";
 import StateDropdown from "../components/StateDropdown";
 import CTPPlot, { CTPDataPoint } from "../components/CTPPlot";
+
+import { Line } from "react-chartjs-2";
+import { ChartPoint, TimeUnit } from "chart.js";
 
 import fetch from "../lib/fetch";
 
@@ -31,6 +34,9 @@ const fetchCovidData = async (
 const Index: NextPage = () => {
   const [data, setData] = useState<CTPDataPoint[] | null>(null);
 
+  type ChartData = { [key: string]: ChartPoint[] };
+  const [chartData, setChartData] = useState<ChartData>({});
+
   const onChange: FormControlProps["onChange"] = async (
     event
   ): Promise<void> => {
@@ -38,6 +44,34 @@ const Index: NextPage = () => {
     const results = await fetchCovidData(state);
 
     setData(results);
+  };
+
+  const onIHMEUpdate: IHMEParserProps["onUpdate"] = (data) => {
+    setChartData(data);
+  };
+
+  const lineData = {
+    datasets: Object.keys(chartData)
+      .sort()
+      .map((key) => {
+        return {
+          label: key,
+          data: chartData[key],
+        };
+      }),
+  };
+
+  const options = {
+    scales: {
+      xAxes: [
+        {
+          type: "time",
+          time: {
+            unit: "day" as TimeUnit,
+          },
+        },
+      ],
+    },
   };
 
   return (
@@ -49,11 +83,16 @@ const Index: NextPage = () => {
       </Row>
       <Row>
         <Col>
-          <IHMEParser />
+          <IHMEParser onUpdate={onIHMEUpdate} />
         </Col>
       </Row>
       <Row>
         <Col>{data && <CTPPlot data={data} />}</Col>
+      </Row>
+      <Row>
+        <Col>
+          <Line data={lineData} options={options}></Line>
+        </Col>
       </Row>
     </Container>
   );

--- a/styles.scss
+++ b/styles.scss
@@ -1,0 +1,1 @@
+@import "~bootstrap/scss/bootstrap";


### PR DESCRIPTION
# Summary
This PR introduces functionality to parse IHME data files and plot death data for the currently selected state. Files and be imported via a drag-and-drop interface, and series data in the resulting plot is labeled according the modification date of the file. Multiple files can be imported at once, each plotted as a separate data series. More specific changes are enumerated below.

# Changes
- Installed `react-file-drop` package installed to provide drag-and-drop file importing

- Installed `papaparse` CSV parsing package to read and parse IHME CSV data to a JSON object

- Added `IHMEParser.tsx` component to provide an interface for importing data files and parsing the associated files. A callback function is used to notify an observer whenever data changes have been made. This is used to update a chart on the `index.tsx` page.

- Turned off  `@typescript-eslint/interface-name-prefix` typescript linting rule